### PR TITLE
Minor Changes

### DIFF
--- a/Library/MapleBacon/MapleBacon.xcodeproj/project.pbxproj
+++ b/Library/MapleBacon/MapleBacon.xcodeproj/project.pbxproj
@@ -86,8 +86,8 @@
 			children = (
 				268605FF1A3F341000BA4269 /* ImageViewExtension.swift */,
 				26B702151A4040DE00E3FB72 /* ImageManager.swift */,
-				26B702421A41803900E3FB72 /* ImageGifExtension.swift */,
 				31AA3B2762299015563F040F /* ImageDownloadOperation.swift */,
+				26B702421A41803900E3FB72 /* ImageGifExtension.swift */,
 				26E1F2021B2C2A2600901E94 /* Delay.swift */,
 			);
 			name = Downloader;

--- a/Library/MapleBacon/MapleBacon/Delay.swift
+++ b/Library/MapleBacon/MapleBacon/Delay.swift
@@ -4,12 +4,7 @@
 
 import Foundation
 
-
 func delay(delay:Double, closure:()->()) {
-    dispatch_after(
-        dispatch_time(
-            DISPATCH_TIME_NOW,
-            Int64(delay * Double(NSEC_PER_SEC))
-        ),
-        dispatch_get_main_queue(), closure)
+    let time = dispatch_time(DISPATCH_TIME_NOW, Int64(delay * Double(NSEC_PER_SEC)))
+    dispatch_after(time, dispatch_get_main_queue(), closure)
 }

--- a/Library/MapleBacon/MapleBacon/ImageDownloadOperation.swift
+++ b/Library/MapleBacon/MapleBacon/ImageDownloadOperation.swift
@@ -43,6 +43,7 @@ public class ImageDownloadOperation: NSOperation {
         task?.cancelByProducingResumeData {
             [unowned self] data in
             self.resumeData = data
+            self.finished = true
         }
     }
 
@@ -53,6 +54,19 @@ public class ImageDownloadOperation: NSOperation {
         }
     }
 
+    
+    override public var finished: Bool {
+        get {
+            return _finished
+        }
+        set {
+            willChangeValueForKey("isFinished")
+            _finished = newValue
+            didChangeValueForKey("isFinished")
+        }
+    }
+    
+    private var _finished = false
 }
 
 extension ImageDownloadOperation: NSURLSessionDownloadDelegate {
@@ -75,12 +89,14 @@ extension ImageDownloadOperation: NSURLSessionDownloadDelegate {
             } else {
                 completionHandler?(nil, error)
             }
+            self.finished = true
     }
 
     public func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
         if let error = error {
             println("Remote error: \(error), \(error.userInfo)")
             completionHandler?(nil, error)
+            self.finished = true
         }
     }
 
@@ -91,7 +107,6 @@ extension ImageDownloadOperation: NSURLSessionDownloadDelegate {
         self.imageURL = request.URL!
         resumeDownload()
     }
-
 }
 
 public enum ImageInstanceState {

--- a/Library/MapleBacon/MapleBacon/ImageManager.swift
+++ b/Library/MapleBacon/MapleBacon/ImageManager.swift
@@ -6,29 +6,21 @@ import UIKit
 
 public class ImageManager {
 
-    private var downloadsInProgress = [NSURL: ImageDownloadOperation]()
-    private var downloadQueue: NSOperationQueue {
-        let queue = NSOperationQueue()
-        queue.maxConcurrentOperationCount = 10
-        return queue
-    }
+    internal var downloadsInProgress = [NSURL: ImageDownloadOperation]()
+    
+    // The Download Queue
+    private lazy var downloadQueue = NSOperationQueue()
 
-    public class var sharedManager: ImageManager {
-
-        struct Singleton {
-            static let instance = ImageManager()
-        }
-
-        return Singleton.instance
-    }
+    // Singleton Support
+    public static let sharedManager = ImageManager()
 
     deinit {
         downloadQueue.cancelAllOperations()
     }
 
-    public func downloadImageAtURL(url: NSURL, cacheScaled: Bool, imageView: UIImageView?,
-                                   storage: Storage = MapleBaconStorage.sharedStorage,
-                                   completion: ImageDownloaderCompletion?) -> ImageDownloadOperation? {
+    public func downloadImageAtURL(url: NSURL, cacheScaled: Bool, imageView: UIImageView?, storage: Storage = MapleBaconStorage.sharedStorage, completion: ImageDownloaderCompletion?) -> ImageDownloadOperation? {
+        
+        // If image is in the cache, then return it
         if let cachedImage = storage.image(forKey: url.absoluteString!) {
             completion?(ImageInstance(image: cachedImage, state: .Cached, url: url), nil)
         } else {
@@ -51,7 +43,6 @@ public class ImageManager {
                 }
                 downloadsInProgress[url] = downloadOperation
                 downloadQueue.addOperation(downloadOperation)
-
                 return downloadOperation
             } else {
                 completion?(ImageInstance(image: nil, state: .Downloading, url: nil), nil)

--- a/Library/MapleBacon/MapleBacon/ImageViewExtension.swift
+++ b/Library/MapleBacon/MapleBacon/ImageViewExtension.swift
@@ -4,7 +4,8 @@
 
 import UIKit
 
-var ImageViewAssociatedObjectHandle: UInt8 = 0
+private var ImageViewAssociatedObjectHandle: UInt8 = 0
+private var ImageViewURLAssociatedObjectHandle: UInt8 = 0
 
 extension UIImageView {
 
@@ -38,9 +39,21 @@ extension UIImageView {
                     objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
         }
     }
+    
+    var url: NSURL? {
+        get {
+            return objc_getAssociatedObject(self, &ImageViewURLAssociatedObjectHandle) as? NSURL
+        }
+        set {
+            objc_setAssociatedObject(self, &ImageViewURLAssociatedObjectHandle, newValue, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+        }
+    }
 
     func cancelDownload() {
         operation?.cancel()
+        if url != nil {
+            ImageManager.sharedManager.downloadsInProgress.removeValueForKey(url!)
+        }
     }
 
 }

--- a/Library/MapleBacon/MapleBacon/Storage/DiskStorage.swift
+++ b/Library/MapleBacon/MapleBacon/Storage/DiskStorage.swift
@@ -9,20 +9,21 @@ public class DiskStorage: Storage {
     let fileManager: NSFileManager = {
         return NSFileManager.defaultManager()
     }()
+    
     let storageQueue: dispatch_queue_t = {
         dispatch_queue_create("de.zalando.MapleBacon.Storage", DISPATCH_QUEUE_SERIAL)
     }()
+    
     let storagePath: String
 
     public var maxAge: NSTimeInterval = 60 * 60 * 24 * 7
 
+    // Singleton support
     public class var sharedStorage: DiskStorage {
-
         struct Singleton {
-            static let instance = DiskStorage()
+            static let shared = DiskStorage()
         }
-
-        return Singleton.instance
+        return Singleton.shared
     }
 
     public convenience init() {
@@ -32,10 +33,11 @@ public class DiskStorage: Storage {
     public init(name: String) {
         let paths = NSSearchPathForDirectoriesInDomains(.CachesDirectory, .UserDomainMask, true)
         storagePath = (paths.first as! NSString).stringByAppendingPathComponent("de.zalando.MapleBacon.\(name)")
-
         fileManager.createDirectoryAtPath(storagePath, withIntermediateDirectories: true, attributes: nil, error: nil)
     }
 
+    // MARK: - Storage Protocol
+    
     public func storeImage(image: UIImage, var data: NSData?, forKey key: String) {
         dispatch_async(storageQueue) {
             if (data == nil) {
@@ -46,18 +48,46 @@ public class DiskStorage: Storage {
         }
     }
 
-    public func pruneStorage() {
+    public func image(forKey key: String) -> UIImage? {
+        if let data = NSData(contentsOfFile: defaultStoragePath(forKey: key)) {
+            return UIImage.imageWithCachedData(data)
+        }
+        return nil
+    }
+
+    public func removeImage(forKey key: String) {
         dispatch_async(storageQueue) {
-            if let directoryURL = NSURL(fileURLWithPath: self.storagePath, isDirectory: true),
-            let enumerator = self.fileManager.enumeratorAtURL(directoryURL,
-                    includingPropertiesForKeys: [NSURLIsDirectoryKey, NSURLContentModificationDateKey],
-                    options: .SkipsHiddenFiles,
-                    errorHandler: nil) {
-                self.deleteExpiredFiles(self.expiredFiles(usingEnumerator: enumerator))
-            }
+            self.fileManager.removeItemAtPath(self.defaultStoragePath(forKey: key), error: nil)
+            return
         }
     }
 
+    public func clearStorage() {
+        dispatch_async(storageQueue) {
+            self.fileManager.removeItemAtPath(self.storagePath, error: nil)
+            self.fileManager.createDirectoryAtPath(self.storagePath, withIntermediateDirectories: true, attributes: nil,
+                    error: nil)
+        }
+    }
+    
+    public func pruneStorage() {
+        dispatch_async(storageQueue) {
+            if let directoryURL = NSURL(fileURLWithPath: self.storagePath, isDirectory: true),
+                let enumerator = self.fileManager.enumeratorAtURL(directoryURL,
+                    includingPropertiesForKeys: [NSURLIsDirectoryKey, NSURLContentModificationDateKey],
+                    options: .SkipsHiddenFiles,
+                    errorHandler: nil) {
+                        self.deleteExpiredFiles(self.expiredFiles(usingEnumerator: enumerator))
+            }
+        }
+    }
+    
+    // MARK: - Helper Functions
+    
+    private func defaultStoragePath(forKey key: String) -> String {
+        return (storagePath as NSString).stringByAppendingPathComponent(key.MD5())
+    }
+    
     private func expiredFiles(usingEnumerator enumerator: NSDirectoryEnumerator) -> [NSURL] {
         let expirationDate = NSDate(timeIntervalSinceNow: -maxAge)
         var expiredFiles = [NSURL]()
@@ -83,47 +113,16 @@ public class DiskStorage: Storage {
         }
         return false
     }
-
+    
     private func modificationDate(fileURL: NSURL) -> NSDate? {
         var modificationDateResource: AnyObject?
         fileURL.getResourceValue(&modificationDateResource, forKey: NSURLContentModificationDateKey, error: nil)
         return modificationDateResource as? NSDate
     }
-
+    
     private func deleteExpiredFiles(files: [NSURL]) {
         for file in files {
             fileManager.removeItemAtURL(file, error: nil)
         }
     }
-
-    public func image(forKey key: String) -> UIImage? {
-        if let data = NSData(contentsOfFile: defaultStoragePath(forKey: key)) {
-            return UIImage.imageWithCachedData(data)
-        }
-        return nil
-    }
-
-    private func defaultStoragePath(forKey key: String) -> String {
-        return storagePath(forKey: key, inPath: storagePath)
-    }
-
-    private func storagePath(forKey key: String, inPath path: String) -> String {
-        return (path as NSString).stringByAppendingPathComponent(key.MD5())
-    }
-
-    public func removeImage(forKey key: String) {
-        dispatch_async(storageQueue) {
-            self.fileManager.removeItemAtPath(self.defaultStoragePath(forKey: key), error: nil)
-            return
-        }
-    }
-
-    public func clearStorage() {
-        dispatch_async(storageQueue) {
-            self.fileManager.removeItemAtPath(self.storagePath, error: nil)
-            self.fileManager.createDirectoryAtPath(self.storagePath, withIntermediateDirectories: true, attributes: nil,
-                    error: nil)
-        }
-    }
-
 }

--- a/Library/MapleBacon/MapleBacon/Storage/InMemoryStorage.swift
+++ b/Library/MapleBacon/MapleBacon/Storage/InMemoryStorage.swift
@@ -4,31 +4,28 @@
 
 import UIKit
 
-public class InMemoryStorage: Storage {
+public class InMemoryStorage: NSCache, Storage {
 
-    let cache: NSCache = {
-        return NSCache()
-    }()
-
+    // Singleton Support
     public class var sharedStorage: InMemoryStorage {
-
         struct Singleton {
-            static let instance = InMemoryStorage()
+            static let shared = InMemoryStorage()
         }
-
-        return Singleton.instance
+        return Singleton.shared
     }
 
-    public convenience init() {
-        self.init(name: "default")
+    public convenience init(name: String) {
+        self.init()
+        self.name = "de.zalando.MapleBacon.\(name)"
     }
-
-    public init(name: String) {
-        cache.name = "de.zalando.MapleBacon.\(name)"
+    
+    // Make it private so that only the top init is used
+    private override init() {
+        super.init()
     }
 
     public func storeImage(image: UIImage, data: NSData?, forKey key: String) {
-        cache.setObject(image, forKey: key, cost: cacheCost(forImage: image))
+        setObject(image, forKey: key, cost: cacheCost(forImage: image))
     }
 
     private func cacheCost(forImage image: UIImage) -> Int {
@@ -40,15 +37,15 @@ public class InMemoryStorage: Storage {
     }
 
     public func image(forKey key: String) -> UIImage? {
-        return cache.objectForKey(key) as? UIImage
+        return objectForKey(key) as? UIImage
     }
 
     public func removeImage(forKey key: String) {
-        cache.removeObjectForKey(key)
+        removeObjectForKey(key)
     }
 
     public func clearStorage() {
-        cache.removeAllObjects()
+        removeAllObjects()
     }
 
 }

--- a/Library/MapleBacon/MapleBacon/Storage/MD5.swift
+++ b/Library/MapleBacon/MapleBacon/Storage/MD5.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-let shift : [UInt32] = [7, 12, 17, 22, 5, 9, 14, 20, 4, 11, 16, 23, 6, 10, 15, 21]
-let table: [UInt32] = (0 ..< 64).map { UInt32(0x100000000 * abs(sin(Double($0 + 1)))) }
+private let shift : [UInt32] = [7, 12, 17, 22, 5, 9, 14, 20, 4, 11, 16, 23, 6, 10, 15, 21]
+private let table: [UInt32] = (0 ..< 64).map { UInt32(0x100000000 * abs(sin(Double($0 + 1)))) }
 
-extension String {
-    public func MD5() -> String {
+public extension String {
+    func MD5() -> String {
         return toHexString(md5(Array(self.utf8)))
     }
 }
 
-func md5(var message: [UInt8]) -> [UInt8] {
+internal func md5(var message: [UInt8]) -> [UInt8] {
     var messageLenBits = UInt64(message.count) * 8
     message.append(0x80)
     while message.count % 64 != 56 {
@@ -69,6 +69,6 @@ func md5(var message: [UInt8]) -> [UInt8] {
     return result
 }
 
-func toHexString(bytes: [UInt8]) -> String {
+private func toHexString(bytes: [UInt8]) -> String {
     return "".join(bytes.map { String(format:"%02x", $0) })
 }

--- a/Library/MapleBacon/MapleBacon/Storage/Storage.swift
+++ b/Library/MapleBacon/MapleBacon/Storage/Storage.swift
@@ -5,21 +5,14 @@
 import UIKit
 
 public protocol Storage {
-
     func storeImage(image: UIImage, data: NSData?, forKey key: String)
-
     func image(forKey key: String) -> UIImage?
-
     func removeImage(forKey key: String)
-
     func clearStorage()
-
 }
 
 public protocol CombinedStorage {
-
     func clearMemoryStorage()
-
 }
 
 public class MapleBaconStorage: Storage, CombinedStorage {
@@ -27,16 +20,15 @@ public class MapleBaconStorage: Storage, CombinedStorage {
     let inMemoryStorage: Storage
     let diskStorage: Storage
 
+    // Singleton support
     public class var sharedStorage: MapleBaconStorage {
-
         struct Singleton {
-            static let instance = MapleBaconStorage()
+            static let shared = MapleBaconStorage()
         }
-
-        return Singleton.instance
+        return Singleton.shared
     }
 
-    init() {
+    private init() {
         inMemoryStorage = InMemoryStorage.sharedStorage
         diskStorage = DiskStorage.sharedStorage
     }

--- a/MapleBaconExample/MapleBaconExample/ImageManagerExample.swift
+++ b/MapleBaconExample/MapleBaconExample/ImageManagerExample.swift
@@ -6,10 +6,9 @@ import UIKit
 import MapleBacon
 
 class ImageCell: UICollectionViewCell {
-
     @IBOutlet weak var imageView: UIImageView?
-
     override func prepareForReuse() {
+        super.prepareForReuse()
         self.imageView?.image = nil
     }
 }
@@ -19,6 +18,7 @@ class ImageExampleViewController: UICollectionViewController {
     var imageURLs = ["http://media.giphy.com/media/lI6nHr5hWXlu0/giphy.gif"]
 
     override func viewDidLoad() {
+        super.viewDidLoad()
         if let file = NSBundle.mainBundle().pathForResource("imageURLs", ofType: "plist"),
            let paths = NSArray(contentsOfFile: file) {
                 for url in paths {
@@ -27,7 +27,6 @@ class ImageExampleViewController: UICollectionViewController {
         }
 
         collectionView?.reloadData()
-        super.viewDidLoad()
     }
 
     override func viewWillAppear(animated: Bool) {
@@ -42,7 +41,7 @@ class ImageExampleViewController: UICollectionViewController {
 
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
-        MapleBaconStorage.sharedStorage.clearMemoryStorage()
+        MapleBaconStorage.sharedStorage.clearStorage()
     }
 
     @IBAction func clearCache(sender: AnyObject) {


### PR DESCRIPTION
- Now there is only one operation queue rather one being created every time the UIImageView extension API is called.
- Updated the ImageDownloadOperation to override the finished property on the NSOperation. This is essential because we are using only one operation queue.
- Changes in visibility of variables and functions
- Using the new way to create singletons
- InMemoryStorage is now a subclass of NSCache and adopts the Storage protocol
- Other small updates