### PR TITLE
fix nsstring/swiftstring incompatibility

### DIFF
--- a/Library/MapleBacon/MapleBacon/Storage/DiskStorage.swift
+++ b/Library/MapleBacon/MapleBacon/Storage/DiskStorage.swift
@@ -30,7 +30,7 @@ public class DiskStorage: Storage {
     }
 
     public init(name: String) {
-        let path = NSSearchPathForDirectoriesInDomains(.CachesDirectory, .UserDomainMask, true).first!
+        let path = NSSearchPathForDirectoriesInDomains(.CachesDirectory, .UserDomainMask, true).first! as NSString
         storagePath = path.stringByAppendingPathComponent("de.zalando.MapleBacon.\(name)")
         
         do {


### PR DESCRIPTION
Since Xcode7 beta 5 `NSSearchPathForDirectoriesInDomains` returns an array of String instead of NSString. As String doesn't have method called `stringByAppendingPathComponent` this breaks the current version. String to NSString is a safe cast, so this change shouldn't be a problem.