### PR TITLE
Fix the bundle identifier for the library target

### DIFF
--- a/MapleBacon.xcodeproj/project.pbxproj
+++ b/MapleBacon.xcodeproj/project.pbxproj
@@ -430,6 +430,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zalando.MapleBacon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -451,6 +452,7 @@
 					"$(inherited)",
 					"$(SDKROOT)/usr/lib/system",
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.zalando.MapleBacon;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};


### PR DESCRIPTION
When the framework was included into a project, the target could not be started causing Xcode to show the ambiguous error message:
- When ran on a device:
> The application does not contain a valid bundle identifier.

- When ran in the simulator:
> LaunchServicesError Code=0

After observing the device console, the detailed error was:
> <Warning>: __dispatch_source_read_socket_block_invoke:234: Failed to install application at file:///<PATH_REDACTED>/ : Error Domain=LaunchServicesError Code=0 "(null)" UserInfo={Error=MissingBundleIdentifier, ErrorDescription=Bundle at path <PATH_REDACTED>/Frameworks/MapleBacon.framework did not have a CFBundleIdentifier in its Info.plist}


Setting the bundle identifier of the target fixes the issue.