### PR TITLE
fixes a bug that causes a crash when UIImage.ImageWithCachedData is called with NSData of zero length

### DIFF
--- a/Library/MapleBacon/MapleBacon/ImageGifExtension.swift
+++ b/Library/MapleBacon/MapleBacon/ImageGifExtension.swift
@@ -8,6 +8,8 @@ import ImageIO
 extension UIImage {
 
     class func imageWithCachedData(data: NSData) -> UIImage? {
+        guard data.length > 0 else { return nil }
+        
         return isAnimatedImage(data) ? animatedImageWithData(data) : UIImage(data: data)
     }
 

--- a/Library/MapleBacon/MapleBaconTests/ImageExtensionTests.swift
+++ b/Library/MapleBacon/MapleBaconTests/ImageExtensionTests.swift
@@ -4,7 +4,7 @@
 
 import XCTest
 import UIKit
-import MapleBacon
+@testable import MapleBacon
 
 class ImageExtensionTests: XCTestCase {
 
@@ -27,4 +27,8 @@ class ImageExtensionTests: XCTestCase {
         }
     }
 
+    func test_whenDataIsEmpty_thenImageWithCachedDataReturnsNilWithoutCrashing() {
+        let emptyData = NSData()
+        XCTAssertNil(UIImage.imageWithCachedData(emptyData))
+    }
 }


### PR DESCRIPTION
fixes a bug that causes a crash when UIImage.ImageWithCachedData is called with NSData of zero length