### PR TITLE
ImageDownloaderCompletion can be racey

### DIFF
--- a/Library/MapleBacon/MapleBacon/ImageDownloadOperation.swift
+++ b/Library/MapleBacon/MapleBacon/ImageDownloadOperation.swift
@@ -86,8 +86,10 @@ extension ImageDownloadOperation: NSURLSessionDownloadDelegate {
             let newData = try NSData(contentsOfURL: location, options: NSDataReadingOptions.DataReadingMappedIfSafe)
             let newImage = UIImage.imageWithCachedData(newData)
             let newImageInstance = ImageInstance(image: newImage, data: newData, state: .New, url: imageURL)
+            if (self.cancelled == true) { return }
             completionHandler?(newImageInstance, nil)
         } catch let error as NSError {
+            if (self.cancelled == true) { return }
             completionHandler?(nil, error)
         }
         self.finished = true
@@ -95,6 +97,10 @@ extension ImageDownloadOperation: NSURLSessionDownloadDelegate {
 
     public func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
         if let error = error {
+            if (self.cancelled == true) {
+                finished = true
+                return
+            }
             completionHandler?(nil, error)
             finished = true
         }

--- a/Library/MapleBacon/MapleBacon/ImageViewExtension.swift
+++ b/Library/MapleBacon/MapleBacon/ImageViewExtension.swift
@@ -4,7 +4,8 @@
 
 import UIKit
 
-private var ImageViewAssociatedObjectHandle: UInt8 = 0
+private var ImageViewAssociatedObjectOperationHandle: UInt8 = 0
+private var ImageViewAssociatedObjectKeyHandle: UInt8 = 1
 
 extension UIImageView {
 
@@ -14,6 +15,7 @@ extension UIImageView {
             image = placeholder
         }
         cancelDownload()
+        self.key = url
         if let operation = downloadOperationWithURL(url, placeholder: placeholder, crossFadePlaceholder: crossFade,
             cacheScaled: cacheScaled, completion: completion) {
             self.operation = operation
@@ -29,7 +31,9 @@ extension UIImageView {
                     if let _ = placeholder where crossFade && instance.state != .Cached {
                         self?.layer.addAnimation(CATransition(), forKey: nil)
                     }
-                    self?.image = instance.image
+                    if (self?.key == instance.url) {
+                        self?.image = instance.image
+                    }
                 }
                 completion?(imageInstance, error)
             }
@@ -38,16 +42,28 @@ extension UIImageView {
 
     private var operation: ImageDownloadOperation? {
         get {
-            return objc_getAssociatedObject(self, &ImageViewAssociatedObjectHandle) as? ImageDownloadOperation
+            return objc_getAssociatedObject(self, &ImageViewAssociatedObjectOperationHandle) as? ImageDownloadOperation
         }
         set {
-            objc_setAssociatedObject(self, &ImageViewAssociatedObjectHandle, newValue,
+            objc_setAssociatedObject(self, &ImageViewAssociatedObjectOperationHandle, newValue,
                     objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
     }
+    
+    private var key: NSURL? {
+        get {
+            return objc_getAssociatedObject(self, &ImageViewAssociatedObjectKeyHandle) as? NSURL
+        }
+        set {
+            objc_setAssociatedObject(self, &ImageViewAssociatedObjectKeyHandle, newValue,
+                objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
 
+    
     func cancelDownload() {
         operation?.cancel()
+        key = nil
     }
 
 }


### PR DESCRIPTION
### Issue ###
Scrolling through a tableview or collectionview results in flickering between two different images.  Sometimes the wrong image can also be set.

### Analysis ###
When cancelDownload() is called on the NSOperation on the queue there is no guarantee that the operation will be completely canceled (https://developer.apple.com/library/ios/documentation/Cocoa/Reference/NSOperation_class/#//apple_ref/doc/uid/TP40004591-RH2-SW18)
What is guaranteed is that the cancelled property will be set.  When we see this we shouldn't call the completionHandler with the ImageInstance.

The other issue seems to be a race for when we have a cached image.  If the user scrolls quickly in the view the reusable cell, the cell could catch an old image loading after the new one is set.  I don't know your thoughts here, but for now I am piggy backing on the AssociatedObject stuff to make sure we are only setting the image if it matches the key, where the key is the url.